### PR TITLE
Issue events bug fixes and enhancements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # projmgr (development version)
 
+# projmgr 0.1.0.9000
+
+* Fixed error in `has_n_commits()` taskboard helper and unit test to attribute events to the correct issues
+* Changed behavior of `get_issue_events()` to create minimal dummy event 
+    - Dummy events are identifiable by  `id = -9999` and `event = "exists"`. Other fields not populated to emphasize non-standard event type. 
+    - This enables easier mapping. For example, users may now write `purrr::map_df(issues$number, ~get_issue_events(my_repo, .x) %>% parse_issue_events())` which would have previously thrown an error
+    - New behavior can be disabled with new `dummy_events` argument
+
 # projmgr 0.1.0
 
 * Enhanced test suite to prepare for official release

--- a/R/get.R
+++ b/R/get.R
@@ -74,12 +74,19 @@ get_issue_events <- function(ref, number){
                     ref = ref)
 
   # append the relevant issue number to each element
-  if( res != "" ){
+  if (res != "") {
     res <- lapply(res,
                   FUN = function(x){
                     x[["number"]] = number
                     return(x)
                   })
+  }
+  else {# when there were no results, create mock result for easy mapping
+    res <- list(list(
+        id = -9999,
+        number = number,
+        event = "created"
+    ))
   }
   res
 

--- a/R/get.R
+++ b/R/get.R
@@ -55,7 +55,13 @@ get_issues <- function(ref, limit = 1000, ...){
 #' to which the returned events correspond.
 #'
 #' @inherit get_engine return params
+#'
+#' @param ref
+#' @param dummy_events Logical for whether or not to create a 'dummy' event to denote the
+#'     existence of issues which have no events. Defaults to TRUE (to allow creation). Default
+#'     behavior makes the process of mapping over multiple issues simpler.
 #' @param number Number of issue
+#'
 #' @export
 #'
 #' @family issues
@@ -64,11 +70,18 @@ get_issues <- function(ref, limit = 1000, ...){
 #' @examples
 #' \dontrun{
 #' myrepo <- create_repo_ref('emilyriederer', 'myrepo')
+#'
+#' # single issue workflow
 #' events_res <- get_issue_events(myrepo, number = 1)
 #' events <- parse_issue_events(events_res)
+#'
+#' # multi-issue workflow
+#' issue_res <- get_issues(my_repo, state = 'open')
+#' issues <- parse_issues(issues_res)
+#' events <- purrr::map_df(issues$number, ~get_issue_events(myrepo, .x) %>% parse_issue_events())
 #' }
 
-get_issue_events <- function(ref, number){
+get_issue_events <- function(ref, number, dummy_events = TRUE){
 
   res <- get_engine(api_endpoint = paste0("/issues/", number, "/events"),
                     ref = ref)
@@ -81,11 +94,11 @@ get_issue_events <- function(ref, number){
                     return(x)
                   })
   }
-  else {# when there were no results, create mock result for easy mapping
+  else if(dummy_events) {# when there were no results, create mock result for easy mapping
     res <- list(list(
         id = -9999,
         number = number,
-        event = "created"
+        event = "exists"
     ))
   }
   res

--- a/R/taskboard-helpers.R
+++ b/R/taskboard-helpers.R
@@ -160,9 +160,9 @@ has_n_commits <- function(events, n = 1) {
   n_commits <-
     vapply(data$number,
            FUN = function(x) {
-             z <- which(x == ref_counts$event)
+             z <- which(x == ref_counts$number)
              if (length(z) == 0) 0
-             else z
+             else ref_counts$event[z]
              },
            numeric(1))
   n_commits >= n

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -136,6 +136,21 @@
       <small>Source: <a href='https://github.com/emilyriederer/projmgr/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
+    <div id="projmgr-0-1-0-9000" class="section level1">
+<h1 class="page-header">
+<a href="#projmgr-0-1-0-9000" class="anchor"></a>projmgr 0.1.0.9000<small> Unreleased </small>
+</h1>
+<ul>
+<li>Fixed error in <code><a href="../reference/taskboard_helpers.html">has_n_commits()</a></code> taskboard helper and unit test to attribute events to the correct issues</li>
+<li>Changed behavior of <code><a href="../reference/get_issue_events.html">get_issue_events()</a></code> to create minimal dummy event
+<ul>
+<li>Dummy events are identifiable by <code>id = -9999</code> and <code>event = "exists"</code>. Other fields not populated to emphasize non-standard event type.</li>
+<li>This enables easier mapping. For example, users may now write <code><a href="https://purrr.tidyverse.org/reference/map.html">purrr::map_df(issues$number, ~get_issue_events(my_repo, .x) %&gt;% parse_issue_events())</a></code> which would have previously thrown an error</li>
+<li>New behavior can be disabled with new <code>dummy_events</code> argument</li>
+</ul>
+</li>
+</ul>
+</div>
     <div id="projmgr-0-1-0" class="section level1">
 <h1 class="page-header">
 <a href="#projmgr-0-1-0" class="anchor"></a>projmgr 0.1.0<small> 2019-08-05 </small>
@@ -201,6 +216,7 @@
     <div id="tocnav">
       <h2>Contents</h2>
       <ul class="nav nav-pills nav-stacked">
+        <li><a href="#projmgr-0-1-0-9000">0.1.0.9000</a></li>
         <li><a href="#projmgr-0-1-0">0.1.0</a></li>
         <li><a href="#projmgr-0-0-0-9902">0.0.0.9902</a></li>
         <li><a href="#projmgr-0-0-0-9901">0.0.0.9901</a></li>

--- a/docs/reference/get_issue_events.html
+++ b/docs/reference/get_issue_events.html
@@ -84,7 +84,7 @@ to which the returned events correspond." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">projmgr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.0.9902</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9000</span>
       </span>
     </div>
 
@@ -147,7 +147,7 @@ to which the returned events correspond.</p>
     
     </div>
 
-    <pre class="usage"><span class='fu'>get_issue_events</span>(<span class='no'>ref</span>, <span class='no'>number</span>)</pre>
+    <pre class="usage"><span class='fu'>get_issue_events</span>(<span class='no'>ref</span>, <span class='no'>number</span>, <span class='kw'>dummy_events</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -159,6 +159,12 @@ to which the returned events correspond.</p>
     <tr>
       <th>number</th>
       <td><p>Number of issue</p></td>
+    </tr>
+    <tr>
+      <th>dummy_events</th>
+      <td><p>Logical for whether or not to create a 'dummy' event to denote the
+existence of issues which have no events. Defaults to TRUE (to allow creation). Default
+behavior makes the process of mapping over multiple issues simpler.</p></td>
     </tr>
     </table>
     
@@ -182,8 +188,15 @@ to which the returned events correspond.</p>
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><span class='co'># NOT RUN {</span>
 <span class='no'>myrepo</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='create_repo_ref.html'>create_repo_ref</a></span>(<span class='st'>'emilyriederer'</span>, <span class='st'>'myrepo'</span>)
+
+<span class='co'># single issue workflow</span>
 <span class='no'>events_res</span> <span class='kw'>&lt;-</span> <span class='fu'>get_issue_events</span>(<span class='no'>myrepo</span>, <span class='kw'>number</span> <span class='kw'>=</span> <span class='fl'>1</span>)
 <span class='no'>events</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='parse_issue_events.html'>parse_issue_events</a></span>(<span class='no'>events_res</span>)
+
+<span class='co'># multi-issue workflow</span>
+<span class='no'>issue_res</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='get_issues.html'>get_issues</a></span>(<span class='no'>my_repo</span>, <span class='kw'>state</span> <span class='kw'>=</span> <span class='st'>'open'</span>)
+<span class='no'>issues</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='parse_issues.html'>parse_issues</a></span>(<span class='no'>issues_res</span>)
+<span class='no'>events</span> <span class='kw'>&lt;-</span> <span class='kw pkg'>purrr</span><span class='kw ns'>::</span><span class='fu'><a href='https://purrr.tidyverse.org/reference/map.html'>map_df</a></span>(<span class='no'>issues</span>$<span class='no'>number</span>, ~<span class='fu'>get_issue_events</span>(<span class='no'>myrepo</span>, <span class='no'>.x</span>) <span class='kw'>%&gt;%</span> <span class='fu'><a href='parse_issue_events.html'>parse_issue_events</a></span>())
 <span class='co'># }</span></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">projmgr</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9000</span>
       </span>
     </div>
 

--- a/man/get_issue_events.Rd
+++ b/man/get_issue_events.Rd
@@ -4,12 +4,16 @@
 \alias{get_issue_events}
 \title{Get events for a specific issue from GitHub repository}
 \usage{
-get_issue_events(ref, number)
+get_issue_events(ref, number, dummy_events = TRUE)
 }
 \arguments{
 \item{ref}{Repository reference (list) created by \code{create_repo_ref()}}
 
 \item{number}{Number of issue}
+
+\item{dummy_events}{Logical for whether or not to create a 'dummy' event to denote the
+existence of issues which have no events. Defaults to TRUE (to allow creation). Default
+behavior makes the process of mapping over multiple issues simpler.}
 }
 \value{
 Content of GET request as list
@@ -21,8 +25,15 @@ to which the returned events correspond.
 \examples{
 \dontrun{
 myrepo <- create_repo_ref('emilyriederer', 'myrepo')
+
+# single issue workflow
 events_res <- get_issue_events(myrepo, number = 1)
 events <- parse_issue_events(events_res)
+
+# multi-issue workflow
+issue_res <- get_issues(my_repo, state = 'open')
+issues <- parse_issues(issues_res)
+events <- purrr::map_df(issues$number, ~get_issue_events(myrepo, .x) \%>\% parse_issue_events())
 }
 }
 \seealso{

--- a/tests/testthat/test-tb-helpers.R
+++ b/tests/testthat/test-tb-helpers.R
@@ -26,6 +26,7 @@ test_that( "Issue-specific taskboard helpers evaluate correctly with expected in
   expect_equal( is_created_before("2020-03-01")(df_issue), c(TRUE, TRUE, TRUE))
 
   expect_equal( has_n_commits(df_events)(df_issue), c(TRUE, TRUE, FALSE))
+  expect_equal( has_n_commits(df_events, n = 1)(df_issue), c(TRUE, TRUE, FALSE))
   expect_equal( has_n_commits(df_events, n = 2)(df_issue), c(TRUE, FALSE, FALSE))
   expect_equal( has_n_commits(df_events, n = 3)(df_issue), c(FALSE, FALSE, FALSE))
 


### PR DESCRIPTION
Made multiple changes in response to and inspired by #14 . This PR:

- fixes incorrect behavior and tests for `has_n_commits()`
- enhances `get_issue_events()` by creating dummy events unless explicitly disabled